### PR TITLE
Packaging (merge after the gitignore pull request)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,62 @@
 .ipynb_checkpoints
 *~
-*.pyc
 *#
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+uvdata/tests/cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/katalogss/__init__.py
+++ b/katalogss/__init__.py
@@ -1,0 +1,4 @@
+from .fhd_pype import *
+from .katalogss import *
+from .kg_utils import *
+from .utils import *

--- a/katalogss/__init__.py
+++ b/katalogss/__init__.py
@@ -1,4 +1,11 @@
-from .fhd_pype import *
-from .katalogss import *
-from .kg_utils import *
-from .utils import *
+from . import fhd_pype
+from . import katalogss
+from . import kg_utils
+from . import utils
+# use the below style of import if you want the things inside the various files
+# to be in the katalogss namespace rather than the katalogss.file namespace
+# e.g: katalogss.clip_comps vs katalogss.katalogss.clip_comps
+# from .fhd_pype import *
+# from .katalogss import *
+# from .kg_utils import *
+# from .utils import *

--- a/scripts/source-finding.ipynb
+++ b/scripts/source-finding.ipynb
@@ -22,8 +22,8 @@
     "import warnings\n",
     "import pandas as pd\n",
     "from astropy.wcs import WCS\n",
-    "import fhd_pype as fp\n",
-    "import katalogss as kg\n",
+    "import katalogss.fhd_pype as fp\n",
+    "import katalogss.katalogss as kg\n",
     "\n",
     "warnings.filterwarnings('ignore')\n"
    ]


### PR DESCRIPTION
Added **init**.py with two options for namespace arrangements (one is commented out). Also updated the imports in the jupyter notebook to reflect the packaging. With these fixes I can run the notebook in its standard location after running setup.py install.
